### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,103 @@
 
 # cert-viewer
 
-The cert-viewer project is a Flask webapp to display and verify blockchain certificates after they have been issued and
-to allow learners to request a certificate and generate their own Bitcoin identity needed for the certificate creation
- process. 
+The cert-viewer project is a Flask webapp to display and verify blockchain certificates after they have been issued and to allow learners to request a certificate and generate their own Bitcoin identity needed for the certificate creation process. 
 
-## Quick Start using Docker
+## Install and Run
 
-### Steps
+1. Ensure you have a python environment. [Recommendations](https://github.com/blockchain-certificates/developer-common-docs/blob/master/virtualenv.md)
 
+2. Git clone the repository and change to the directory
+
+    ```bash
+    git clone https://github.com/blockchain-certificates/cert-viewer.git && cd cert-viewer
+    ```
+
+3. Setup your conf.ini file (see 'Configuration')
+
+4. Run cert-viewer setup
+
+    ```bash
+    pip install .
+    ```
+
+5. Run the flask server
+
+    ```shell
+    python run.py -c conf_local.ini
+    ```
+
+6. Open `http://localhost:5000`
+
+### Using GridFS
+
+The basic configuration uses a file system certificate store, under the `cert_data` directory. To use GridFS instead, install [mongodb](https://docs.mongodb.com/v3.0/installation/) and start mongo database before running cert-viewer.
+
+## Deployment considerations
+
+The quick start made simplifications that you would not want in a real deployment. Here are some of the factors to consider:
+
+### Certificate storage
+
+Cert-viewer relies on the Blockchain Certificates module [cert-store](https://github.com/blockchain-certificates/cert-store) for accessing certificates. This uses the [simplekv](https://github.com/mbr/simplekv) for extensibility. By default, cert-viewer is configured to use a file system key value store, pointing to the `cert-data` folder. See [cert-store](https://github.com/blockchain-certificates/cert-store) for information on other certificate storage options. 
+
+### Recipient introductions/requests
+
+Early Blockchain Certificates deployments assumed recipients would fill out the 'certificate request' form (included in this project) to provide their information such as name, email, and bitcoin address. This web form is no longer needed if your recipients are using [cert-wallet](https://github.com/blockchain-certificates/cert-wallet). Cert-wallet is easier for recipients to use because it handles key generation.
+
+Cert-viewer exposes an `introduction` REST endpoint used by both cert-wallet and, if you are using it, the web form. Advanced configuration options allow the `introduction` endpoint to store the certificates in mongodb, but this would ideally be changes to an interface supporting a broad range of data stores.
+
+You may host the `introduction` endpoint in a separate location, but make sure to specify that location in the issuer identity json.
+
+It is assumed that you will perform your own orchestration after receiving an introduction/request and before issuing. For example, you would want to verify the recipient is eligible, etc.
+
+#### Notifications
+
+If you expose the 'certificate request' form, you may enable mandrill email alerts. This is mainly kept for backwards compatibility -- if you want to use this, you may choose to generalize or improve the `notifier.py` class.
+
+If you are enabling mandrill email notificates, you may use a template like this [receipt-template Mandrill template](https://us13.admin.mailchimp.com/templates/share?id=56461169_1921351b9adabaa4610f_us13). 
+
+Also see the `notifier`, `mandrill_api_key`, and `subject` configuration options.
+
+### Site templates and themes
+
+Cert-viewer uses [Flask-Themes2](http://flask-themes2.readthedocs.io/en/latest/) to allow you to personalize your deployment. This would include your organization's images, stylesheets, and flask templates. See cert_viewer\themes for examples.
+
+You would also include your issuer identification json file under <your_theme>\static\issuer
+
+
+## Configuration
+
+The quick start instructions use the basic configuration options in `conf_local.ini`. This describes all available configuration options. Refer to 'Deployment considerations' for additional details about these options.
+
+1. Copy the template ini file
+
+    ```bash
+    cp conf_template.ini conf.ini
+    ```
+    
+2. Basic configuration options:
+    - `secret_key` is a random string used by Flask as a secret key to enable cryptographically signed session
+    - `cert_store_path` is the file system path to the certificates
+    - `theme` is the Flask Theme you want to use for your styling, static content, and templates. We provide a few configuration options for your issuer branding, but in a real deployment, issuers should extend the base theme to provide their own styling. Cert-viewer uses [Flask-Themes2](http://flask-themes2.readthedocs.io/en/latest/)
+    - `issuer_email` is used in the flask templates for your contact info
+    - `issuer_name` is used in the flask templates for your organization name
+    - `issuer_logo_path` is used in the flask templates as a path to organization's logo
+    - `recent_certids` is a comma-separated list of certificate uids. Use this if you want to show sample certificates on your home page.  
+        
+3. Advanced configuration options:
+    - `cert_store_type` is the type of key value store to use for certificates, using simplekv. simplekv_fs uses the file system, and simplekv_gridfs uses gridfs
+        - when using gridfs (mongodb) as a certificate store you can use `mongo-seed/load_gfs.py` script to load the certificates into mongodb    
+    - `mongodb_uri` is used to access your mongodb instance for storing recipient introductions/requests. The canonical form is `mongodb://<username>:<password>@<domain>:<mongo_port>/<db_name>`. Examples follow:
+        - Local mongo installation: `mongodb_uri = mongodb://localhost:27017/test`
+        - Docker installation: `mongodb_uri = mongodb://<DOCKER_MACHINE_IP>:27017/test`, where DOCKER_MACHINE_IP is given by `docker-machine ip`
+    - `notifier` is a noop by default. This is used if you want to enable web form certificate requests, as opposed to or in addition to, cert-wallet introductions. To send mandrill notifications, use `mail`
+    - `mandrill_api_key` if notifier is `mail`, this is used to send out notifications when a user signs up. Setup your mandrill account at https://www.mandrill.com/
+    - `subject` if using a `mail` notifier, this is the subject line to use
+
+## Advanced: Docker Setup
+
+To experiment with running cert-viewer and enable recipient introductions stored in MongoDB, you can use our Docker files.
 
 1. First ensure you have Docker installed. [See our Docker installation help](https://github.com/blockchain-certificates/developer-common-docs/blob/master/docker_install.md).
    
@@ -35,111 +124,6 @@ to allow learners to request a certificate and generate their own Bitcoin identi
     ```
     web_1         | INFO -  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
     ```
-
-
-### About Docker Setup
-The quick start steps do the following:
-
-1. Creates a container that runs the cert-viewer Flask app with MongoDB using Docker Compose [details](http://containertutorials.com/docker-compose/flask-mongo-compose.html)
-2. Copies the certificates in cert_data into the Docker container's file system.
-3. Starts the container. This configuration exposes port 5000.
-
-## Deployment considerations
-
-The quick start made simplifications that you would not want in a real deployment. Here are some of the factors to consider:
-
-### Certificate storage
-
-Cert-viewer relies on the Blockchain Certificates module [cert-store](https://github.com/blockchain-certificates/cert-store) for accessing certificates. This uses the [simplekv](https://github.com/mbr/simplekv) for extensibility. By default, cert-viewer is configured to use a file system key value store, pointing to the `cert-data` folder. See [cert-store](https://github.com/blockchain-certificates/cert-store) for information on other certificate storage options. 
-
-### Recipient introductions/requests
-
-Early Blockchain Certificates deployments assumed recipients would fill out the 'certificate request' form (included in this project) to provide their information such as name, email, and bitcoin address. This web form is no longer needed if your recipients are using [cert-wallet](https://github.com/blockchain-certificates/cert-wallet). Cert-wallet is easier for recipients to use because it handles key generation.
-
-Cert-viewer exposes an `introduction` REST endpoint used by both cert-wallet and, if you are using it, the web form. The `introduction` endpoint is currently configured to store the certificates in mongodb, but this would ideally be changes to an interface supporting a broad range of data stores.
-
-You may host the `introduction` endpoint in a separate location, but make sure to specify that location in the issuer identity json.
-
-It is assumed that you will perform your own orchestration after receiving an introduction/request and before issuing. For example, you would want to verify the recipient is eligible, etc.
-
-#### Notifications
-
-If you expose the 'certificate request' form, you may enable mandrill email alerts. This is mainly kept for backwards compatibility -- if you want to use this, you may choose to generalize or improve the `notifier.py` class.
-
-If you are enabling mandrill email notificates, you may use a template like this [receipt-template Mandrill template](https://us13.admin.mailchimp.com/templates/share?id=56461169_1921351b9adabaa4610f_us13). 
-
-Also see the `notifier`, `mandrill_api_key`, and `subject` configuration options.
-
-
-### Site templates and themes
-
-Cert-viewer uses [Flask-Themes2](http://flask-themes2.readthedocs.io/en/latest/) to allow you to personalize your deployment. This would include your organization's images, stylesheets, and flask templates. See cert_viewer\themes for examples.
-
-You would also include your issuer identification json file under <your_theme>\static\issuer
-
-## Configuration
-
-Refer to 'Deployment considerations' for additional details about these options.
-
-1. Copy the template ini file
-
-    ```bash
-    cp conf_template.ini conf.ini
-    ```
-    
-2. Edit the following entries (refer to conf_sample.ini for examples):
-    - `secret_key` is a random string used by Flask as a secret key to enable cryptographically signed session
-    - `cert_store_type` is the type of key value store to use for certificates, using simplekv. simplekv_fs uses the file system, and simplekv_gridfs uses gridfs
-        - when using gridfs (mongodb) as a certificate store you can use `mongo-seed/load_gfs.py` script to load the certificates into mongodb
-    - `cert_store_path` is the file system path to the certificates
-    - `theme` is the Flask Theme you want to use for your styling, static content, and templates. We provide a few configuration options for your issuer branding, but in a real deployment, issuers should extend the base theme to provide their own styling. Cert-viewer uses [Flask-Themes2](http://flask-themes2.readthedocs.io/en/latest/)
-    - `issuer_email` is used in the flask templates for your contact info
-    - `issuer_name` is used in the flask templates for your organization name
-    - `issuer_logo_path` is used in the flask templates as a path to organization's logo
-    - `mongodb_uri` is used to access your mongodb instance for storing recipient introductions/requests. The canonical form is `mongodb://<username>:<password>@<domain>:<mongo_port>/<db_name>`. Examples follow:
-        - Local mongo installation: `mongodb_uri = mongodb://localhost:27017/test`
-        - Docker installation: `mongodb_uri = mongodb://<DOCKER_MACHINE_IP>:27017/test`, where DOCKER_MACHINE_IP is given by `docker-machine ip`
-    - `recent_certids` is a comma-separated list of certificate uids. Use this if you want to show sample certificates on your home page.    
-    - `notifier` is a noop by default. This is used if you want to enable web form certificate requests, as opposed to or in addition to, cert-wallet introductions. To send mandrill notifications, use `mail`
-    - `mandrill_api_key` if notifier is `mail`, this is used to send out notifications when a user signs up. Setup your mandrill account at https://www.mandrill.com/
-    - `subject` if using a `mail` notifier, this is the subject line to use
-
-
-## Running outside of Docker
-
-These steps allow you to install and run outside outside of Docker.
-
-1. Ensure you have an python environment. [Recommendations](https://github.com/blockchain-certificates/developer-common-docs/blob/master/virtualenv.md)
-
-2. If using mongodb (see 'Deployment Considerations'), install [mongodb](https://docs.mongodb.com/v3.0/installation/)
-
-3. Git clone the repository and change to the directory
-
-    ```bash
-    git clone https://github.com/blockchain-certificates/cert-viewer.git && cd cert-viewer
-    ```
-
-4. Setup your conf.ini file (see 'Configuration')
-
-5. If using mongodb (see 'Deployment Considerations'), start mongo database. `--dbpath` can be left off if you used the default location
-
-    ```shell
-    mongod --dbpath <path to data directory>
-    ```
-
-6. Run cert-viewer setup
-
-    ```bash
-    pip install .
-    ```
-
-7. Run the flask server
-
-    ```shell
-    python run.py
-    ```
-
-8. Open `http://localhost:5000`
 
 ## Unit tests
 

--- a/cert-viewer-local.env
+++ b/cert-viewer-local.env
@@ -7,3 +7,4 @@ RECENT_CERTIDS=b5dee02e-50cd-4e48-ad33-de7d2eafa359,f813349f-1385-487f-8d89-38a0
 SECRET_KEY=\xe0\xfd\x7f-\x9b:0\xda?_\xfd**iO\xdb|d\xff\x80\xa7\xce\x8e\xbe
 CERT_STORE_TYPE=simplekv_fs
 CERT_STORE_PATH=/etc/cert_data
+THEME=original

--- a/cert_viewer/verifier_bridge.py
+++ b/cert_viewer/verifier_bridge.py
@@ -1,4 +1,4 @@
-from cert_store.model import BlockcertVersion
+from cert_core.model import BlockcertVersion
 from cert_verifier import verifier
 
 

--- a/conf_local.ini
+++ b/conf_local.ini
@@ -4,14 +4,6 @@ cert_store_type=simplekv_fs
 cert_store_path=cert_data
 
 issuer_name=A Blockchain Certificates Issuer
-issuer_logo_path=img/lm.jpg
+issuer_logo_path=img/logo.png
 issuer_email=your@email.org
-
-mongodb_uri=mongodb://localhost:27017/test
-
-# notifiers are optionally used if you're allowing recipients to request certificates via the request form
-notifier_type=noop
-# if enabling email alerts
-from_email=issuer_email@you.com
-from_name=Issuer name
-subject=Your request for a certificate is being processed
+theme=default

--- a/conf_local.ini
+++ b/conf_local.ini
@@ -1,4 +1,4 @@
-recent_certids=49f08049-2f02-4346-a846-aee25c3fe70d,157be4e5-00a1-4da6-83fb-04ba9d9c6bfa
+recent_certids=b5dee02e-50cd-4e48-ad33-de7d2eafa359,f813349f-1385-487f-8d89-38a092411fa5
 secret_key=\xe0\xfd\x7f-\x9b:0\xda?_\xfd**iO\xdb|d\xff\x80\xa7\xce\x8e\xbe
 cert_store_type=simplekv_fs
 cert_store_path=cert_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ mongomock>=2.0.0
 tox>=2.3.1
 configargparse>=0.10.0
 cert-verifier>=1.2.14
-cert-store>=0.0.18
+cert-store>=0.0.19
 flasgger>=0.5.14
 simplekv>=0.10.0
 Flask-Themes2==0.1.4

--- a/tests/test_certificate_formatter.py
+++ b/tests/test_certificate_formatter.py
@@ -2,7 +2,7 @@ import unittest
 import json
 
 from cert_viewer import certificate_formatter
-from cert_store.model import V1_2_BlockchainCertificate
+from cert_core.model import V1_2_BlockchainCertificate
 
 
 class TestCertificateFormatter(unittest.TestCase):


### PR DESCRIPTION
Now that we have the file system certificate store, it's easier for new users to run outside of docker, which was originally introduced to simplify separate MongoDB setup.

Cleanup instructions.