### PR TITLE
Fix an issue in the cert viewer verification. Verified icon doesnt ge…

### DIFF
--- a/cert_viewer/static/js/verification.js
+++ b/cert_viewer/static/js/verification.js
@@ -37,7 +37,7 @@ markMappings = {"passed": "PASS", "failed": "FAIL", "done": "DONE", "not_started
 
 $(document).ready(function () {
     $("#verify-button").click(function () {
-        hidefields("#not-verified", "#verified");
+        hidefields(["#not-verified", "#verified"]);
         $("#progress-msg").html("");
         var data = $(this).attr('value');
         var uid = JSON.parse(data.replace(/'/g, '"')).uid;


### PR DESCRIPTION
…t removed as soon as you restart verification process

The function was expecting the arrays of ID to hide the Verified/Non Verified message. Apparently there was a type and brackets were not specified while calling the function which resulted in error.

Steps to reproduce issue
1.Verify certificate by clicking "Verify Certificate" button
2.Revoke same certificate
3.Click on Verify Certificate button again

Result:
Failed on revoke step however final outcome is appearing as both "Verified" and "Not Verified"
Expected Result:
It should fail on revoke step and final outcome should appear as "Not Verified"