### PR TITLE
upgrade Flask-Themes2, fix SyntaxError

### DIFF
--- a/cert_viewer/notifier.py
+++ b/cert_viewer/notifier.py
@@ -56,7 +56,7 @@ class Mail(Notifier):
             logging.debug('sending mandrill receipt template')
             result = mandrill_client.messages.send_template(template_name='receipt-template',
                                                             template_content=template_content, message=message,
-                                                            async=False)
+                                                            send_async=False)
             return result
         except mandrill.Error as e:
             error_message = 'A mandrill error occurred: %s - %s' % (

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ configargparse>=0.13.0
 flasgger>=0.8.3
 Flask>=1.0
 Flask-PyMongo>=0.5.1
-Flask-Themes2==0.1.4
+Flask-Themes2>0.1.4
 Flask-WTF>=0.14.2
 mandrill>=1.0.57
 mock>=2.0.0


### PR DESCRIPTION
This PR fixes the following issues:

```python
Traceback (most recent call last):
  File "run.py", line 4, in <module>
    from cert_viewer import configure_app
  File "/home/ubuntu/cert-viewer/cert_viewer/__init__.py", line 6, in <module>
    from flask_themes2 import (Themes)
  File "/usr/local/lib/python3.8/dist-packages/flask_themes2/__init__.py", line 36, in <module>
    from werkzeug import cached_property
ImportError: cannot import name 'cached_property' from 'werkzeug' (/usr/local/lib/python3.8/dist-packages/werkzeug/__init__.py)
```
See https://github.com/jarus/flask-testing/issues/143 for more info on this problem. flask-themes2 fixed this in https://github.com/sysr-q/flask-themes2/commit/ea872ec6701f317ae2a87db2bbeac19722390a7a, so upgrading to a version of flask-themes2 newer than Feb 13 2020 should fix this. https://pypi.org/project/Flask-Themes2/#history would suggest 0.1.5 or 1.0.0 would work.

```python
Traceback (most recent call last):
  File "run.py", line 16, in <module>
    main()
  File "run.py", line 10, in main
    configure_app(conf)
  File "/home/ubuntu/cert-viewer/cert_viewer/__init__.py", line 56, in configure_app
    views.add_rules(app, configuration)
  File "/home/ubuntu/cert-viewer/cert_viewer/views/__init__.py", line 66, in add_rules
    from cert_viewer.views.request_view import RequestView
  File "/home/ubuntu/cert-viewer/cert_viewer/views/request_view.py", line 10, in <module>
    from cert_viewer.notifier import Notifier
  File "/home/ubuntu/cert-viewer/cert_viewer/notifier.py", line 59
    async=False)
    ^
SyntaxError: invalid syntax
```
See https://bitbucket.org/mailchimp/mandrill-api-python/commits/95106841ba96027825313912ea8f212db0059389 for more info on this problem. Fixes https://github.com/blockchain-certificates/cert-viewer/issues/75 and https://github.com/blockchain-certificates/cert-viewer/issues/77